### PR TITLE
更新了部署文档中的一些错误信息

### DIFF
--- a/docs/preparation.md
+++ b/docs/preparation.md
@@ -20,17 +20,16 @@ heartbeat:                              # 心跳包设置
 
 servers:
   - http:                               # http 通信设置
-    host: 127.0.0.1                     # host
-    port: 5700                          # port
-    timeout: 5                          # 反向 http 超时时间
-    long-polling:                       
-      enabled: false
-      max-queue-size: 2000
-    middlewares:                        
-      <<: *default
-    port:                               # 反向 http 设置
-    = url: 'http://127.0.0.1:5701'      # 反向 http 服务器地址
-      secret: ''                        # 验证密钥，无
+      address: 127.0.0.1:5700               # HTTP监听地址
+      timeout: 5                          # 反向 http 超时时间
+      long-polling:                       
+        enabled: false
+        max-queue-size: 2000
+      middlewares:                        
+        <<: *default
+      post:                               # 反向 http 设置
+      - url: 'http://127.0.0.1:5701'      # 反向 http 服务器地址
+        secret: ''                        # 验证密钥，无
 ```
 
 go-cqhttp 与 go-cqhttp-js 可不在同一台服务器运行


### PR DESCRIPTION
实际部署的时候，发现完全照抄文档跑不起来。翻阅了[go-cqhttp的部署文档](https://docs.go-cqhttp.org/guide/config.html#%E9%85%8D%E7%BD%AE%E4%BF%A1%E6%81%AF) 发现文档中有些内容有误（主要是缩进与字段名称）。

更新了 “配置 go-cqhttp” 一节中过时与错误的内容
